### PR TITLE
Use the latest version of KissXML to fix a build issue

### DIFF
--- a/LastFm.podspec
+++ b/LastFm.podspec
@@ -1,16 +1,16 @@
 Pod::Spec.new do |s|
   s.name         = "LastFm"
-  s.version      = "1.17.0"
+  s.version      = "1.18.0"
   s.summary      = "Block based Last.fm SDK for iOS and Mac OS X."
   s.homepage     = "https://github.com/gangverk/LastFm"
   s.license      = 'MIT'
   s.author       = { "Kevin Renskers" => "info@mixedcase.nl" }
   s.source       = { :git => "https://github.com/gangverk/LastFm.git", :tag => s.version.to_s }
-  s.ios.deployment_target = '6.0'
-  s.osx.deployment_target = '10.8'
+  s.ios.deployment_target = '8.0'
+  s.osx.deployment_target = '10.9'
   s.tvos.deployment_target = '9.0'
   s.source_files = 'LastFm/*.{h,m}'
   s.requires_arc = true
   s.xcconfig     = { 'HEADER_SEARCH_PATHS' => '"$(SDKROOT)/usr/include/libxml2"' }
-  s.dependency 'KissXML', '~> 5.0.3'
+  s.dependency 'KissXML', '~> 5.2.3'
 end


### PR DESCRIPTION
KissXML fixed a build issue introduced in Xcode 9.3 with https://github.com/robbiehanson/KissXML/commit/24842063a24bf29bf14136a2a727dd5ad9eec69b. 

This PR updates KissXML to the latest released version, which also requires updating the minimum version for iOS and macOS. 

This is a really minor change, but because of that minimum OS version change I bumped the version of LastFM to `1.18.0`